### PR TITLE
Add latest SilverStripe advisories

### DIFF
--- a/illuminate/cookie/2018-08-08-1.yaml
+++ b/illuminate/cookie/2018-08-08-1.yaml
@@ -1,0 +1,35 @@
+title:     Cookie serialization vulnerability
+link:      https://laravel.com/docs/5.6/upgrade#upgrade-5.6.30
+cve:       ~
+branches:
+    4.0.x:
+        time:     ~
+        versions: ['>=4.0.0', '<=4.0.11']
+    4.1.x:
+        time:     ~
+        versions: ['>=4.1.0', '<=4.1.31']
+    4.2.x:
+        time:     ~
+        versions: ['>=4.2.0', '<=4.2.22']
+    5.0.x:
+        time:     ~
+        versions: ['>=5.0.0', '<=5.0.35']
+    5.1.x:
+        time:     ~
+        versions: ['>=5.1.0', '<=5.1.46']
+    5.2.x:
+        time:     ~
+        versions: ['>=5.2.0', '<=5.2.45']
+    5.3.x:
+        time:     ~
+        versions: ['>=5.3.0', '<=5.3.31']
+    5.4.x:
+        time:     ~
+        versions: ['>=5.4.0', '<=5.4.36']
+    5.5.x:
+        time:     2018-08-07 18:07:12
+        versions: ['>=5.5.0', '<5.5.42']
+    5.6.x:
+        time:     2018-08-07 07:53:14
+        versions: ['>=5.6.0', '<5.6.30']
+reference: composer://illuminate/cookie

--- a/laravel/framework/2018-08-08-1.yaml
+++ b/laravel/framework/2018-08-08-1.yaml
@@ -1,0 +1,35 @@
+title:     Cookie serialization vulnerability
+link:      https://laravel.com/docs/5.6/upgrade#upgrade-5.6.30
+cve:       ~
+branches:
+    4.0.x:
+        time:     ~
+        versions: ['>=4.0.0', '<=4.0.11']
+    4.1.x:
+        time:     ~
+        versions: ['>=4.1.0', '<=4.1.31']
+    4.2.x:
+        time:     ~
+        versions: ['>=4.2.0', '<=4.2.22']
+    5.0.x:
+        time:     ~
+        versions: ['>=5.0.0', '<=5.0.35']
+    5.1.x:
+        time:     ~
+        versions: ['>=5.1.0', '<=5.1.46']
+    5.2.x:
+        time:     ~
+        versions: ['>=5.2.0', '<=5.2.45']
+    5.3.x:
+        time:     ~
+        versions: ['>=5.3.0', '<=5.3.31']
+    5.4.x:
+        time:     ~
+        versions: ['>=5.4.0', '<=5.4.36']
+    5.5.x:
+        time:     2018-08-07 18:07:12
+        versions: ['>=5.5.0', '<5.5.42']
+    5.6.x:
+        time:     2018-08-07 07:53:14
+        versions: ['>=5.6.0', '<5.6.30']
+reference: composer://laravel/framework

--- a/symfony/http-foundation/CVE-2018-14773.yaml
+++ b/symfony/http-foundation/CVE-2018-14773.yaml
@@ -1,0 +1,53 @@
+title:     "CVE-2018-14773: Remove support for legacy and risky HTTP headers"
+link:      https://symfony.com/blog/cve-2018-14773-remove-support-for-legacy-and-risky-http-headers
+cve:       CVE-2018-14773
+branches:
+    2.0.x:
+        time:     ~
+        versions: ['>=2.0.0', '<2.1.0']
+    2.1.x:
+        time:     ~
+        versions: ['>=2.1.0', '<2.2.0']
+    2.2.x:
+        time:     ~
+        versions: ['>=2.2.0', '<2.3.0']
+    2.3.x:
+        time:     ~
+        versions: ['>=2.3.0', '<2.4.0']
+    2.4.x:
+        time:     ~
+        versions: ['>=2.4.0', '<2.5.0']
+    2.5.x:
+        time:     ~
+        versions: ['>=2.5.0', '<2.6.0']
+    2.6.x:
+        time:     ~
+        versions: ['>=2.6.0', '<2.7.0']
+    2.7.x:
+        time:     2018-08-01 15:57:00
+        versions: ['>=2.7.0', '<2.7.49']
+    2.8.x:
+        time:     2018-08-01 16:12:00
+        versions: ['>=2.8.0', '<2.8.44']
+    3.0.x:
+        time:     ~
+        versions: ['>=3.0.0', '<3.1.0']
+    3.1.x:
+        time:     ~
+        versions: ['>=3.1.0', '<3.2.0']
+    3.2.x:
+        time:     ~
+        versions: ['>=3.2.0', '<3.3.0']
+    3.3.x:
+        time:     2018-08-01 16:04:00
+        versions: ['>=3.3.0', '<3.3.18']
+    3.4.x:
+        time:     2018-08-01 16:48:00
+        versions: ['>=3.4.0', '<3.4.14']
+    4.0.x:
+        time:     2018-08-01 16:58:00
+        versions: ['>=4.0.0', '<4.0.14']
+    4.1.x:
+        time:     2018-08-01 17:30:00
+        versions: ['>=4.1.0', '<4.1.3']
+reference: composer://symfony/http-foundation

--- a/symfony/symfony/CVE-2018-14773.yaml
+++ b/symfony/symfony/CVE-2018-14773.yaml
@@ -1,0 +1,53 @@
+title:     "CVE-2018-14773: Remove support for legacy and risky HTTP headers"
+link:      https://symfony.com/blog/cve-2018-14773-remove-support-for-legacy-and-risky-http-headers
+cve:       CVE-2018-14773
+branches:
+    2.0.x:
+        time:     ~
+        versions: ['>=2.0.0', '<2.1.0']
+    2.1.x:
+        time:     ~
+        versions: ['>=2.1.0', '<2.2.0']
+    2.2.x:
+        time:     ~
+        versions: ['>=2.2.0', '<2.3.0']
+    2.3.x:
+        time:     ~
+        versions: ['>=2.3.0', '<2.4.0']
+    2.4.x:
+        time:     ~
+        versions: ['>=2.4.0', '<2.5.0']
+    2.5.x:
+        time:     ~
+        versions: ['>=2.5.0', '<2.6.0']
+    2.6.x:
+        time:     ~
+        versions: ['>=2.6.0', '<2.7.0']
+    2.7.x:
+        time:     2018-08-01 15:57:00
+        versions: ['>=2.7.0', '<2.7.49']
+    2.8.x:
+        time:     2018-08-01 16:12:00
+        versions: ['>=2.8.0', '<2.8.44']
+    3.0.x:
+        time:     ~
+        versions: ['>=3.0.0', '<3.1.0']
+    3.1.x:
+        time:     ~
+        versions: ['>=3.1.0', '<3.2.0']
+    3.2.x:
+        time:     ~
+        versions: ['>=3.2.0', '<3.3.0']
+    3.3.x:
+        time:     2018-08-01 16:04:00
+        versions: ['>=3.3.0', '<3.3.18']
+    3.4.x:
+        time:     2018-08-01 16:48:00
+        versions: ['>=3.4.0', '<3.4.14']
+    4.0.x:
+        time:     2018-08-01 16:58:00
+        versions: ['>=4.0.0', '<4.0.14']
+    4.1.x:
+        time:     2018-08-01 17:30:00
+        versions: ['>=4.1.0', '<4.1.3']
+reference: composer://symfony/symfony

--- a/zendframework/zend-diactoros/ZF2018-01.yaml
+++ b/zendframework/zend-diactoros/ZF2018-01.yaml
@@ -1,0 +1,7 @@
+title:     URL Rewrite vulnerability
+link:      https://framework.zend.com/security/advisory/ZF2018-01
+branches:
+  master:
+    time:     2018-06-11 15:28:00
+    versions: ['>=1.0.0', '<1.8.4']
+reference: composer://zendframework/zend-diactoros

--- a/zendframework/zend-feed/ZF2018-01.yaml
+++ b/zendframework/zend-feed/ZF2018-01.yaml
@@ -1,0 +1,7 @@
+title:     URL Rewrite vulnerability
+link:      https://framework.zend.com/security/advisory/ZF2018-01
+branches:
+  master:
+    time:     2018-06-11 15:28:00
+    versions: ['>=1.0.0', '<2.10.3']
+reference: composer://zendframework/zend-feed

--- a/zendframework/zend-http/ZF2018-01.yaml
+++ b/zendframework/zend-http/ZF2018-01.yaml
@@ -1,0 +1,7 @@
+title:     URL Rewrite vulnerability
+link:      https://framework.zend.com/security/advisory/ZF2018-01
+branches:
+  master:
+    time:     2018-06-11 15:28:00
+    versions: ['>=1.0.0', '<2.8.1']
+reference: composer://zendframework/zend-http

--- a/zendframework/zendframework/ZF2018-01.yaml
+++ b/zendframework/zendframework/ZF2018-01.yaml
@@ -1,0 +1,7 @@
+title:     URL Rewrite vulnerability
+link:      https://framework.zend.com/security/advisory/ZF2018-01
+branches:
+  master:
+    time:     2018-06-11 15:28:00
+    versions: ['<2.5.0']
+reference: composer://zendframework/zendframework


### PR DESCRIPTION
This PR adds the latest advisories fixed in SilverStripe (supported) modules: https://www.silverstripe.org/download/security-releases/