### PR TITLE
Add latest SilverStripe advisories

### DIFF
--- a/cwp/cwp-installer/ss-2018-012.yaml
+++ b/cwp/cwp-installer/ss-2018-012.yaml
@@ -1,0 +1,8 @@
+title: 'SS-2018-012: Uploaded PHP script execution in assets'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2018-012'
+cve: '~'
+branches:
+    4.0.x:
+        time: '2018-04-24 15:11:11'
+        versions: ['>=4.0.0', '<4.0.4']
+reference: 'composer://cwp/cwp-installer'

--- a/silverstripe/admin/ss-2018-004.yaml
+++ b/silverstripe/admin/ss-2018-004.yaml
@@ -1,0 +1,11 @@
+title: 'SS-2018-004: XSS Vulnerability via WYSIWYG editor'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2018-004'
+cve: '~'
+branches:
+    1.0.x:
+        time: '2018-04-24 12:26:04'
+        versions: ['>=1.0.3', '<1.0.4']
+    1.1.x:
+        time: '2018-04-24 12:26:04'
+        versions: ['>=1.1.0', '<1.1.1']
+reference: 'composer://silverstripe/admin'

--- a/silverstripe/cms/ss-2017-003.yaml
+++ b/silverstripe/cms/ss-2017-003.yaml
@@ -1,0 +1,14 @@
+title: 'SS-2017-003: XSS in RedirectorPage'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2017-003'
+cve: '~'
+branches:
+    3.4.x:
+        time: '2017-06-02 01:52:41'
+        versions: ['>=3.4.0', '<3.4.6']
+    3.5.x:
+        time: '2017-06-02 01:52:41'
+        versions: ['>=3.5.0', '<3.5.4']
+    3.x:
+        time: '2017-06-02 01:52:41'
+        versions: ['>=3.4.0', '<3.6.0']
+reference: 'composer://silverstripe/cms'

--- a/silverstripe/cms/ss-2017-004.yaml
+++ b/silverstripe/cms/ss-2017-004.yaml
@@ -1,0 +1,14 @@
+title: 'SS-2017-004: XSS in page history comparison'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2017-004'
+cve: '~'
+branches:
+    3.4.x:
+        time: '2017-06-02 01:55:25'
+        versions: ['>=3.4.0', '<3.4.6']
+    3.5.x:
+        time: '2017-06-02 01:55:25'
+        versions: ['>=3.5.0', '<3.5.4']
+    3.x:
+        time: '2017-06-02 01:55:25'
+        versions: ['>=3.4.0', '<3.6.0']
+reference: 'composer://silverstripe/cms'

--- a/silverstripe/comments/ss-2018-015.yaml
+++ b/silverstripe/comments/ss-2018-015.yaml
@@ -1,0 +1,5 @@
+title: 'SS-2018-015: Vulnerable dependency'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2018-015'
+cve: '~'
+branches: {  }
+reference: 'composer://silverstripe/comments'

--- a/silverstripe/framework/ss-2016-010.yaml
+++ b/silverstripe/framework/ss-2016-010.yaml
@@ -1,0 +1,17 @@
+title: 'SS-2016-010: ReadOnly transformation for formfields exploitable'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2016-010'
+cve: '~'
+branches:
+    3.1.x:
+        time: '2016-08-02 03:51:30'
+        versions: ['>=3.1.0', '<3.1.21']
+    3.2.x:
+        time: '2016-08-02 03:51:30'
+        versions: ['>=3.2.0', '<3.2.6']
+    3.3.x:
+        time: '2016-08-02 03:51:30'
+        versions: ['>=3.3.0', '<3.3.4']
+    3.x:
+        time: '2016-08-02 03:51:30'
+        versions: ['>=3.1.0', '<3.5.0']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/framework/ss-2016-011.yaml
+++ b/silverstripe/framework/ss-2016-011.yaml
@@ -1,0 +1,11 @@
+title: 'SS-2016-011: ChangePasswordForm doesn''t check Member::canLogIn()'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2016-011'
+cve: '~'
+branches:
+    3.1.x:
+        time: '2016-08-02 03:58:30'
+        versions: ['>=3.1.19', '<3.1.20']
+    3.2.x:
+        time: '2016-08-02 03:58:30'
+        versions: ['>=3.2.4', '<3.2.5']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/framework/ss-2016-013.yaml
+++ b/silverstripe/framework/ss-2016-013.yaml
@@ -1,0 +1,11 @@
+title: 'SS-2016-013: Member.Name isn''t escaped'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2016-013'
+cve: '~'
+branches:
+    3.1.x:
+        time: '2016-08-02 04:04:42'
+        versions: ['>=3.1.19', '<3.1.20']
+    3.2.x:
+        time: '2016-08-02 04:04:42'
+        versions: ['>=3.2.4', '<3.2.5']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/framework/ss-2016-014.yaml
+++ b/silverstripe/framework/ss-2016-014.yaml
@@ -1,0 +1,11 @@
+title: 'SS-2016-014: Pre-existing alc_enc cookies log users in if remember me is disabled'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2016-014'
+cve: '~'
+branches:
+    3.1.x:
+        time: '2016-08-02 04:07:36'
+        versions: ['>=3.1.19', '<3.1.20']
+    3.2.x:
+        time: '2016-08-02 04:07:36'
+        versions: ['>=3.2.4', '<3.2.5']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/framework/ss-2016-015.yaml
+++ b/silverstripe/framework/ss-2016-015.yaml
@@ -1,0 +1,11 @@
+title: 'SS-2016-015: XSS In OptionsetField and CheckboxSetField'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2016-015'
+cve: '~'
+branches:
+    3.1.x:
+        time: '2016-08-02 23:36:50'
+        versions: ['>=3.1.19', '<3.1.20']
+    3.2.x:
+        time: '2016-08-02 23:36:50'
+        versions: ['>=3.2.4', '<3.2.5']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/framework/ss-2016-016.yaml
+++ b/silverstripe/framework/ss-2016-016.yaml
@@ -1,0 +1,17 @@
+title: 'SS-2016-016: XSS In CMSSecurity BackURL'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2016-016'
+cve: '~'
+branches:
+    3.1.x:
+        time: '2016-11-27 22:20:53'
+        versions: ['>=3.1.0', '<3.1.21']
+    3.2.x:
+        time: '2016-11-27 22:20:53'
+        versions: ['>=3.2.0', '<3.2.6']
+    3.3.x:
+        time: '2016-11-27 22:20:53'
+        versions: ['>=3.3.0', '<3.3.4']
+    3.x:
+        time: '2016-11-27 22:20:53'
+        versions: ['>=3.1.0', '<3.5.0']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/framework/ss-2017-001.yaml
+++ b/silverstripe/framework/ss-2017-001.yaml
@@ -1,0 +1,8 @@
+title: 'SS-2017-001: XSS In page name'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2017-001'
+cve: '~'
+branches:
+    3.5.x:
+        time: '2017-01-04 23:00:27'
+        versions: ['>=3.5.0', '<3.5.2']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/framework/ss-2017-002.yaml
+++ b/silverstripe/framework/ss-2017-002.yaml
@@ -1,0 +1,14 @@
+title: 'SS-2017-002: Member disclosure in login form'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2017-002'
+cve: '~'
+branches:
+    3.4.x:
+        time: '2017-06-02 01:52:41'
+        versions: ['>=3.4.0', '<3.4.6']
+    3.5.x:
+        time: '2017-06-02 01:52:41'
+        versions: ['>=3.5.0', '<3.5.4']
+    3.x:
+        time: '2017-06-02 01:52:41'
+        versions: ['>=3.4.0', '<3.6.0']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/framework/ss-2017-005.yaml
+++ b/silverstripe/framework/ss-2017-005.yaml
@@ -1,0 +1,8 @@
+title: 'SS-2017-005: User enumeration via timing attack on login and password reset forms'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2017-005'
+cve: '~'
+branches:
+    3.5.x:
+        time: '2017-06-02 01:55:25'
+        versions: ['>=3.5.0', '<3.5.5']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/framework/ss-2017-006.yaml
+++ b/silverstripe/framework/ss-2017-006.yaml
@@ -1,0 +1,11 @@
+title: 'SS-2017-006: Session user agent change detection'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2017-006'
+cve: '~'
+branches:
+    3.5.x:
+        time: '2017-12-06 00:07:20'
+        versions: ['>=3.5.0', '<3.5.6']
+    3.6.x:
+        time: '2017-12-06 00:07:20'
+        versions: ['>=3.6.0', '<3.6.3']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/framework/ss-2017-007.yaml
+++ b/silverstripe/framework/ss-2017-007.yaml
@@ -1,0 +1,14 @@
+title: 'SS-2017-007: CSV Excel Macro Injection'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2017-007'
+cve: '~'
+branches:
+    3.5.x:
+        time: '2017-12-06 00:07:20'
+        versions: ['>=3.5.0', '<3.5.6']
+    3.6.x:
+        time: '2017-12-06 00:07:20'
+        versions: ['>=3.6.0', '<3.6.3']
+    4.0.x:
+        time: '2017-12-06 00:07:20'
+        versions: ['>=4.0.0', '<4.0.1']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/framework/ss-2017-008.yaml
+++ b/silverstripe/framework/ss-2017-008.yaml
@@ -1,0 +1,14 @@
+title: 'SS-2017-008: SQL injection in full text search of SilverStripe 4'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2017-008'
+cve: '~'
+branches:
+    3.5.x:
+        time: '2017-12-06 00:58:42'
+        versions: ['>=3.5.0', '<3.5.6']
+    3.6.x:
+        time: '2017-12-06 00:58:42'
+        versions: ['>=3.6.0', '<3.6.3']
+    4.0.x:
+        time: '2017-12-06 00:58:42'
+        versions: ['>=4.0.0', '<4.0.1']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/framework/ss-2017-009.yaml
+++ b/silverstripe/framework/ss-2017-009.yaml
@@ -1,0 +1,14 @@
+title: 'SS-2017-009: Users inadvertently passing sensitive data to LoginAttempt'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2017-009'
+cve: '~'
+branches:
+    3.5.x:
+        time: '2017-12-06 01:06:28'
+        versions: ['>=3.5.0', '<3.5.6']
+    3.6.x:
+        time: '2017-12-06 01:06:28'
+        versions: ['>=3.6.0', '<3.6.3']
+    4.0.x:
+        time: '2017-12-06 01:06:28'
+        versions: ['>=4.0.0', '<4.0.1']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/framework/ss-2017-010.yaml
+++ b/silverstripe/framework/ss-2017-010.yaml
@@ -1,0 +1,8 @@
+title: 'SS-2017-010: install.php discloses sensitive data by pre-populating DB credential forms'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2017-010'
+cve: '~'
+branches:
+    4.0.x:
+        time: '2017-12-06 01:09:41'
+        versions: ['>=4.0.0', '<4.0.1']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/framework/ss-2018-001.yaml
+++ b/silverstripe/framework/ss-2018-001.yaml
@@ -1,0 +1,11 @@
+title: 'SS-2018-001: Privilege Escalation Risk in Member Edit form'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2018-001'
+cve: '~'
+branches:
+    3.5.x:
+        time: '2018-04-23 13:41:34'
+        versions: ['>=3.5.7', '<3.5.8']
+    4.0.x:
+        time: '2018-04-23 13:41:34'
+        versions: ['>=4.0.0', '<4.0.4']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/framework/ss-2018-005.yaml
+++ b/silverstripe/framework/ss-2018-005.yaml
@@ -1,0 +1,8 @@
+title: 'SS-2018-005: isDev and isTest unguarded'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2018-005'
+cve: '~'
+branches:
+    4.0.x:
+        time: '2018-04-24 12:50:35'
+        versions: ['>=4.0.0', '<4.0.4']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/framework/ss-2018-006.yaml
+++ b/silverstripe/framework/ss-2018-006.yaml
@@ -1,0 +1,11 @@
+title: 'SS-2018-006: Code execution vulnerability'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2018-006'
+cve: '~'
+branches:
+    4.0.x:
+        time: '2018-04-24 13:45:56'
+        versions: ['>=4.0.3', '<4.0.4']
+    4.1.x:
+        time: '2018-04-24 13:45:56'
+        versions: ['>=4.1.0', '<4.1.1']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/framework/ss-2018-008.yaml
+++ b/silverstripe/framework/ss-2018-008.yaml
@@ -1,0 +1,8 @@
+title: 'SS-2018-008: BackURL validation bypass with malformed URLs'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2018-008'
+cve: '~'
+branches:
+    4.0.x:
+        time: '2018-04-24 14:28:56'
+        versions: ['>=4.0.0', '<4.0.4']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/framework/ss-2018-010.yaml
+++ b/silverstripe/framework/ss-2018-010.yaml
@@ -1,0 +1,8 @@
+title: 'SS-2018-010: Member disclosure in login form'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2018-010'
+cve: '~'
+branches:
+    4.0.x:
+        time: '2018-04-24 14:56:06'
+        versions: ['>=4.0.0', '<4.0.4']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/framework/ss-2018-013.yaml
+++ b/silverstripe/framework/ss-2018-013.yaml
@@ -1,0 +1,14 @@
+title: 'SS-2018-013: Passwords sent back to browsers under some circumstances'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2018-013'
+cve: '~'
+branches:
+    3.x:
+        time: '2018-04-24 15:47:34'
+        versions: ['>=3.5.0', '<3.7.0']
+    4.0.x:
+        time: '2018-04-24 15:47:34'
+        versions: ['>=4.0.3', '<4.0.4']
+    4.1.x:
+        time: '2018-04-24 15:47:34'
+        versions: ['>=4.1.0', '<4.1.1']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/framework/ss-2018-014.yaml
+++ b/silverstripe/framework/ss-2018-014.yaml
@@ -1,0 +1,14 @@
+title: 'SS-2018-014: Dangerous file types in allowed upload'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2018-014'
+cve: '~'
+branches:
+    3.6.x:
+        time: '2018-04-24 16:14:28'
+        versions: ['>=3.6.5', '<3.6.6']
+    4.0.x:
+        time: '2018-04-24 16:14:28'
+        versions: ['>=4.0.3', '<4.0.4']
+    4.1.x:
+        time: '2018-04-24 16:14:28'
+        versions: ['>=4.1.0', '<4.1.1']
+reference: 'composer://silverstripe/framework'

--- a/silverstripe/reports/ss-2016-012.yaml
+++ b/silverstripe/reports/ss-2016-012.yaml
@@ -1,0 +1,11 @@
+title: 'SS-2016-012: Missing ACL on reports'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2016-012'
+cve: '~'
+branches:
+    3.1.x:
+        time: '2016-08-02 04:01:44'
+        versions: ['>=3.1.19', '<3.1.20']
+    3.2.x:
+        time: '2016-08-02 04:01:44'
+        versions: ['>=3.2.4', '<3.2.5']
+reference: 'composer://silverstripe/reports'

--- a/silverstripe/subsites/ss-2018-016.yaml
+++ b/silverstripe/subsites/ss-2018-016.yaml
@@ -1,0 +1,5 @@
+title: 'SS-2018-016: Unsafe SQL Query Construction (Safe Data Source)'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2018-016'
+cve: '~'
+branches: {  }
+reference: 'composer://silverstripe/subsites'

--- a/silverstripe/taxonomy/ss-2018-011.yaml
+++ b/silverstripe/taxonomy/ss-2018-011.yaml
@@ -1,0 +1,11 @@
+title: 'SS-2018-011: SQL injection vulnerability'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2018-011'
+cve: '~'
+branches:
+    1.3.x:
+        time: '2018-04-24 14:59:38'
+        versions: ['>=1.3.0', '<1.3.1']
+    2.0.x:
+        time: '2018-04-24 14:59:38'
+        versions: ['>=2.0.0', '<2.0.1']
+reference: 'composer://silverstripe/taxonomy'

--- a/symbiote/silverstripe-multivaluefield/ss-2018-017.yaml
+++ b/symbiote/silverstripe-multivaluefield/ss-2018-017.yaml
@@ -1,0 +1,8 @@
+title: 'SS-2018-017: Possible PHP Object Injection via Multi-Value Field Extension'
+link: 'https://www.silverstripe.org/download/security-releases/ss-2018-017'
+cve: '~'
+branches:
+    3.x:
+        time: '2018-07-16 23:02:55'
+        versions: ['>=3.0.0', '<3.1.0']
+reference: 'composer://symbiote/silverstripe-multivaluefield'


### PR DESCRIPTION
This PR adds the latest advisories fixed in SilverStripe (supported) modules: https://www.silverstripe.org/download/security-releases/