### PR TITLE
Add CVE-2020-9280 advisory for silverstripe/assets

### DIFF
--- a/silverstripe/assets/CVE-2020-9280.yaml
+++ b/silverstripe/assets/CVE-2020-9280.yaml
@@ -1,0 +1,11 @@
+title:     'CVE-2020-9280: Folders migrated from 3.x may be unsafe to upload to'
+link:      https://www.silverstripe.org/download/security-releases/cve-2020-9280/
+cve:       CVE-2020-9280
+branches:
+    1.0.x:
+        time:     2019-09-24 13:49:59
+        versions: ['>=1.0.0', '<1.4.7']
+    1.5.x:
+        time:     2019-09-24 13:49:59
+        versions: ['>=1.5.0', '<1.5.2']
+reference: composer://silverstripe/assets


### PR DESCRIPTION
I've only added the advisory to assets, because it's the main module affected and it's where the main fix is.

Maybe we should add a matching advisory on framework as well, but I'm not 100% sure.

This PR is only for internal review. Merging it won't do anything. 